### PR TITLE
fix(qwen3-tts-mlx): remove proportional frame trim that truncates target speech

### DIFF
--- a/qwen3-tts-mlx/src/lib.rs
+++ b/qwen3-tts-mlx/src/lib.rs
@@ -725,18 +725,16 @@ impl Synthesizer {
             return Ok((vec![], timing));
         }
 
-        // Text-ratio proportional trim: the model generates codec for the full text
-        // (ref_text + target_text). The first ref_ratio fraction corresponds to ref_text
-        // and must be trimmed. This matches the Python reference implementation.
-        let ref_ratio = ref_text_len as f64 / (ref_text_len + text_token_ids.len() + 1) as f64;
-        let trim_frames = (ref_ratio * gen_codes.len() as f64) as usize;
-        let target_codes = &gen_codes[trim_frames..];
+        // Trimming generated frames again using a text-token ratio heuristic is too
+        // aggressive for some samples and can remove valid target speech from the
+        // beginning of the utterance. Keep the full generated codec sequence here.
+        let trim_frames = 0usize;
+        let target_codes = &gen_codes[..];
 
         info!(
-            "ICL: {} ref frames, {} gen frames, ref_ratio={:.3}, trim={} frames, {} target frames",
+            "ICL: {} ref frames, {} gen frames, trim={} frames, {} target frames",
             ref_code_frames.len(),
             gen_codes.len(),
-            ref_ratio,
             trim_frames,
             target_codes.len(),
         );


### PR DESCRIPTION
#### Problem

synthesize_voice_clone_icl() can silently drop the beginning of the generated audio when the target sentence is longer
than the reference text.

The root cause is a post-generation trim step that estimates how many codec frames correspond to the reference text
using a text-token ratio:

```
let ref_ratio = ref_text_len as f64 / (ref_text_len + text_token_ids.len() + 1) as f64;
let trim_frames = (ref_ratio \* gen_codes.len() as f64) as usize;
let target_codes = &gen_codes[trim_frames..];
```

This heuristic assumes acoustic duration scales linearly with text token count, which does not hold in practice.
Speech rate, pauses, punctuation, and prosody all cause the generated frame distribution to deviate from the token
ratio. The result is that trim_frames can exceed the actual reference portion, cutting into valid target content.

#### Reproduction

```
Reference text (93 encoded frames):
旗亭下马解秋衣, 请贳宜阳一壶酒。 壶中唤天云不开，白昼万里闲凄迷。主人劝我养心骨，莫受俗物相填豗。
Target text:
复杂的问题背后也许没有统一的答案，选择站在正方还是反方，其实取决于你对一系列价值判断的回答。
```

Observed log:

```
ICL text tokens: target=(25), ref=(16)
VoiceClone ICL generation complete: 135 frames
ICL: 93 ref frames, 135 gen frames, ref_ratio=0.381, trim=51 frames, 84 target frames
```

`trim_frames=51` removes frames that belong to the target utterance, causing the first portion of the sentence to be
missing from the output.

#### Why the trim is redundant

The pipeline already handles reference removal on the waveform side:

1. ref_code_frames are prepended to the decode input as decoder warmup context.
2. The full sequence is decoded.
3. The decoded samples corresponding to ref_code_frames are cut from the waveform using a frame-proportional sample
   offset (ref_audio_cut).

The trim_frames step is a second, independent removal pass based on an unreliable heuristic. It provides no benefit
and can corrupt output.

#### Fix

Remove the proportional trim and pass the full generated codec sequence to the decoder:

```
let trim_frames = 0usize;
let target_codes = &gen_codes[..];
```

All other logic — decoder warmup, waveform-side ref_audio_cut, and the 50ms fade-in — is unchanged.
