### PR TITLE
fix(mlx-sys): honor MLX_MACOSX_DEPLOYMENT_TARGET env override

### DIFF
--- a/mlx-rs/mlx-sys/build.rs
+++ b/mlx-rs/mlx-sys/build.rs
@@ -286,9 +286,14 @@ fn build_from_source() {
 
     cmake_args.push("-DCMAKE_METAL_COMPILER=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/metal".to_string());
 
-    cmake_args.push("-DCMAKE_OSX_DEPLOYMENT_TARGET=15.0".to_string());
+    // Honor MLX_MACOSX_DEPLOYMENT_TARGET if set (e.g. "14.0" for macOS 14
+    // targets like the mini4 host), otherwise default to 15.0 for parity
+    // with the upstream prebuilt artifacts. MLX upstream supports >= 14.0.
+    let deployment_target =
+        std::env::var("MLX_MACOSX_DEPLOYMENT_TARGET").unwrap_or_else(|_| "15.0".to_string());
+    cmake_args.push(format!("-DCMAKE_OSX_DEPLOYMENT_TARGET={deployment_target}"));
 
-    std::env::set_var("MACOSX_DEPLOYMENT_TARGET", "15.0");
+    std::env::set_var("MACOSX_DEPLOYMENT_TARGET", &deployment_target);
 
     let status = Command::new("cmake")
         .args(&cmake_args)
@@ -361,9 +366,15 @@ fn link_system_frameworks() {
 
 fn main() {
     println!("cargo:rerun-if-env-changed=MLX_PREBUILT_PATH");
+    println!("cargo:rerun-if-env-changed=MLX_MACOSX_DEPLOYMENT_TARGET");
 
-    std::env::set_var("MACOSX_DEPLOYMENT_TARGET", "15.0");
-    println!("cargo:rustc-link-arg=-mmacosx-version-min=15.0");
+    // Honor MLX_MACOSX_DEPLOYMENT_TARGET if set (e.g. "14.0" for macOS 14
+    // targets like the mini4 host), otherwise default to 15.0 for parity
+    // with the upstream prebuilt artifacts.
+    let deployment_target =
+        std::env::var("MLX_MACOSX_DEPLOYMENT_TARGET").unwrap_or_else(|_| "15.0".to_string());
+    std::env::set_var("MACOSX_DEPLOYMENT_TARGET", &deployment_target);
+    println!("cargo:rustc-link-arg=-mmacosx-version-min={deployment_target}");
 
     // Three-mode detection:
     // 1. Explicit MLX_PREBUILT_PATH env var


### PR DESCRIPTION
## Summary
- Make `mlx-rs/mlx-sys/build.rs` honor `MLX_MACOSX_DEPLOYMENT_TARGET` instead of hardcoding `15.0` at both call sites (line 289 / 291 in `build_from_source`, line 365 / 366 in `main`)
- Default stays at `15.0` so existing builds are unaffected
- Setting `MLX_MACOSX_DEPLOYMENT_TARGET=14.0` produces a binary with `LC_BUILD_VERSION minos=14.0` and a metallib at MTLB v1.2.7 (Metal 3.1) that loads on macOS 14 hosts

## Why
mini4 runs macOS 14.8.5. The current hardcoded `-mmacosx-version-min=15.0` produces a metallib at MTLB v1.2.8 (Metal 3.2). Loading that metallib on macOS 14 throws an uncatchable C++ exception during the qwen3-tts speech-tokenizer warmup:

```
qwen3_tts_mlx: Loading speech tokenizer decoder...
fatal runtime error: Rust cannot catch foreign exceptions, aborting
```

Upstream MLX already supports macOS 14 builds: `CMakeLists.txt` line 133-134 explicitly accepts `CMAKE_OSX_DEPLOYMENT_TARGET >= 14.0`, and Metal 3.2 / Metal 4 (NAX) features are gated behind build-time `MLX_METAL_VERSION GREATER_EQUAL 320 / 400` checks plus runtime `__builtin_available(macOS 15, ...)` gates in `device.cpp`, `resident.cpp`, `fence.cpp`. They all degrade gracefully when the deployment target is 14.0.

## Test plan
- [x] Local build with `MLX_MACOSX_DEPLOYMENT_TARGET=14.0 cargo build --release -p ominix-api` (in sibling OminiX-API repo) succeeds in 2m37s with warnings only
- [x] `otool -l target/release/ominix-api | grep LC_BUILD_VERSION -A4` reports `minos 14.0 sdk 26.2`
- [x] `file target/release/mlx.metallib` reports `MetalLib executable (MacOS), version 1.2.7`
- [x] Deployed to mini4 (macOS 14.8.5): launchd agent boots clean, `/v1/voices` returns 200
- [x] End-to-end TTS round-trip: `POST /v1/audio/tts/qwen3?format=wav` -> 200, 34 KB WAV @ 24 kHz, 3.16s
- [x] No crash during speech-tokenizer warmup; `qwen3_tts_mlx::generate` logs show Decode 9 codec frames -> 17280 samples
- [ ] Default-target build (no env var) unchanged — covered by CI

## Risks
- None for default behavior; only opt-in change via env var