### PR TITLE
perf: MemoryGuard, flash_attention kernel, batched QKV in qwen3-tts

### DIFF
--- a/gpt-sovits-mlx/src/models/t2s.rs
+++ b/gpt-sovits-mlx/src/models/t2s.rs
@@ -1029,6 +1029,7 @@ pub struct T2SGenerate<'a, C> {
     max_tokens: usize,
     generated: usize,
     finished: bool,
+    mem_guard: mlx_rs_core::memory::MemoryGuard,
 }
 
 impl<'a, C> T2SGenerate<'a, C>
@@ -1059,6 +1060,7 @@ where
             max_tokens,
             generated: 0,
             finished: false,
+            mem_guard: mlx_rs_core::memory::MemoryGuard::default_guard(),
         })
     }
 }
@@ -1113,17 +1115,7 @@ where
         self.current_token = next_token.index((.., NewAxis));
         self.generated += 1;
 
-        // Periodic cache clearing to prevent memory accumulation during long sequences
-        if self.generated % 256 == 0 {
-            // SAFETY: mlx_clear_cache() is safe to call at any point. It clears the MLX
-            // computation graph cache, releasing memory from completed operations.
-            // This is called during single-threaded inference with no concurrent MLX
-            // operations, so there's no race condition risk. The function is idempotent
-            // and documented as safe to call from the MLX C API.
-            unsafe {
-                mlx_sys::mlx_clear_cache();
-            }
-        }
+        self.mem_guard.step();
 
         Some(Ok(next_token))
     }

--- a/mixtral-mlx/src/model.rs
+++ b/mixtral-mlx/src/model.rs
@@ -24,6 +24,7 @@ use mlx_rs_core::{
     cache::KeyValueCache,
     error::Error,
     fused_swiglu,
+    memory::MemoryGuard,
     utils::{create_attention_mask, scaled_dot_product_attention, AttentionMask, SdpaMask},
 };
 
@@ -632,6 +633,7 @@ pub struct Generate<'a, C> {
     state: GenerateState<'a>,
     prefetched: Option<Array>,
     token_count: usize,
+    mem_guard: MemoryGuard,
 }
 
 pub enum GenerateState<'a> {
@@ -641,7 +643,7 @@ pub enum GenerateState<'a> {
 
 impl<'a, C: KeyValueCache + Default> Generate<'a, C> {
     pub fn new(model: &'a mut Model, cache: &'a mut Vec<Option<C>>, temp: f32, prompt_token: &'a Array) -> Self {
-        Self { model, cache, temp, state: GenerateState::Prefill { prompt_token }, prefetched: None, token_count: 0 }
+        Self { model, cache, temp, state: GenerateState::Prefill { prompt_token }, prefetched: None, token_count: 0, mem_guard: MemoryGuard::default_guard() }
     }
 
     fn compute_next(&mut self, y: &Array) -> std::result::Result<Array, Exception> {
@@ -683,9 +685,7 @@ impl<'a, C: KeyValueCache + Default> Iterator for Generate<'a, C> {
                 self.prefetched = Some(next_y);
 
                 self.token_count += 1;
-                if self.token_count % 256 == 0 {
-                    unsafe { mlx_sys::mlx_clear_cache(); }
-                }
+                self.mem_guard.step();
                 Some(Ok(current))
             }
         }

--- a/mlx-rs-core/src/lib.rs
+++ b/mlx-rs-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod convert;
 pub mod cache;
 pub mod error;
 pub mod generate;
+pub mod memory;
 pub mod metal_kernels;
 pub mod sampler;
 pub mod speculative;
@@ -28,7 +29,7 @@ pub mod utils;
 
 pub use cache::{ConcatKeyValueCache, KVCache, KeyValueCache};
 pub use error::{Error, Result};
-pub use metal_kernels::{fused_swiglu, fused_modulate};
+pub use metal_kernels::{flash_attention, fused_modulate, fused_swiglu};
 pub use sampler::{DefaultSampler, Sampler};
 pub use utils::{
     create_attention_mask, initialize_rope, scaled_dot_product_attention,

--- a/mlx-rs-core/src/memory.rs
+++ b/mlx-rs-core/src/memory.rs
@@ -1,0 +1,239 @@
+//! GPU memory monitoring and OOM-resilient evaluation.
+//!
+//! Provides safe wrappers around MLX memory APIs and an adaptive retry
+//! mechanism for GPU operations that may fail under memory pressure.
+//!
+//! Inspired by Makepad's progressive buffer reservation strategy
+//! (libs/llama/src/session.rs) which retries with incremental buffer
+//! growth on Metal allocation failures.
+
+/// GPU memory snapshot (all values in bytes).
+#[derive(Debug, Clone, Copy)]
+pub struct MemorySnapshot {
+    /// Memory currently allocated and in use by MLX arrays.
+    pub active: usize,
+    /// Memory held in MLX's cache (freed arrays, available for reuse).
+    pub cache: usize,
+    /// Peak memory usage since process start or last reset.
+    pub peak: usize,
+}
+
+impl MemorySnapshot {
+    /// Total GPU memory currently held (active + cached).
+    pub fn total(&self) -> usize {
+        self.active + self.cache
+    }
+}
+
+impl std::fmt::Display for MemorySnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "active={:.1}MB cache={:.1}MB peak={:.1}MB",
+            self.active as f64 / 1e6,
+            self.cache as f64 / 1e6,
+            self.peak as f64 / 1e6,
+        )
+    }
+}
+
+/// Take a snapshot of current GPU memory usage.
+pub fn memory_snapshot() -> MemorySnapshot {
+    unsafe {
+        let mut active: usize = 0;
+        let mut cache: usize = 0;
+        let mut peak: usize = 0;
+        mlx_sys::mlx_get_active_memory(&mut active);
+        mlx_sys::mlx_get_cache_memory(&mut cache);
+        mlx_sys::mlx_get_peak_memory(&mut peak);
+        MemorySnapshot { active, cache, peak }
+    }
+}
+
+/// Clear MLX's GPU memory cache (frees unused cached allocations).
+///
+/// Safe to call at any point — only releases memory from completed
+/// computation graphs, not in-flight operations.
+pub fn clear_cache() {
+    unsafe {
+        mlx_sys::mlx_clear_cache();
+    }
+}
+
+/// Set the MLX memory limit (maximum bytes MLX will allocate).
+/// Returns the previous limit.
+pub fn set_memory_limit(limit: usize) -> usize {
+    unsafe {
+        let mut prev: usize = 0;
+        mlx_sys::mlx_set_memory_limit(&mut prev, limit);
+        prev
+    }
+}
+
+/// Set the MLX cache limit (maximum bytes MLX will hold in cache).
+/// Returns the previous limit.
+pub fn set_cache_limit(limit: usize) -> usize {
+    unsafe {
+        let mut prev: usize = 0;
+        mlx_sys::mlx_set_cache_limit(&mut prev, limit);
+        prev
+    }
+}
+
+/// Evaluate an MLX array with OOM retry.
+///
+/// On failure, clears the GPU cache and retries up to `max_retries` times.
+/// This handles transient memory pressure from accumulated cache entries
+/// without requiring the caller to manage memory manually.
+///
+/// Returns `Ok(())` on success, or the last error if all retries fail.
+pub fn eval_with_retry(
+    arrays: &[&mlx_rs::Array],
+    max_retries: usize,
+) -> Result<(), mlx_rs::error::Exception> {
+    let mut last_err = None;
+
+    for attempt in 0..=max_retries {
+        match mlx_rs::transforms::eval(arrays.iter().copied()) {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                let msg = format!("{e}");
+                let is_oom = msg.contains("out of memory")
+                    || msg.contains("allocation failed")
+                    || msg.contains("too small");
+
+                if !is_oom || attempt == max_retries {
+                    return Err(e);
+                }
+
+                // Log the retry attempt
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    attempt = attempt + 1,
+                    max_retries,
+                    memory = %memory_snapshot(),
+                    "OOM during eval, clearing cache and retrying"
+                );
+
+                clear_cache();
+                last_err = Some(e);
+            }
+        }
+    }
+
+    Err(last_err.unwrap())
+}
+
+/// Guard that periodically clears GPU cache during long generation loops.
+///
+/// Tracks memory and clears cache when usage exceeds a threshold,
+/// or every N steps — whichever comes first. Replaces the manual
+/// `if step % 256 == 0 { mlx_clear_cache() }` pattern scattered
+/// across model crates.
+pub struct MemoryGuard {
+    /// Clear cache every this many steps regardless of memory pressure.
+    step_interval: usize,
+    /// Clear cache when active memory exceeds this fraction of peak.
+    pressure_threshold: f64,
+    /// Current step counter.
+    step: usize,
+    /// Snapshot at last clear.
+    last_clear: MemorySnapshot,
+}
+
+impl MemoryGuard {
+    /// Create a new MemoryGuard.
+    ///
+    /// - `step_interval`: Force cache clear every N steps (e.g., 256).
+    /// - `pressure_threshold`: Clear when `active / peak > threshold` (e.g., 0.9).
+    pub fn new(step_interval: usize, pressure_threshold: f64) -> Self {
+        Self {
+            step_interval,
+            pressure_threshold,
+            step: 0,
+            last_clear: memory_snapshot(),
+        }
+    }
+
+    /// Default guard: clear every 256 steps or at 90% memory pressure.
+    pub fn default_guard() -> Self {
+        Self::new(256, 0.9)
+    }
+
+    /// Call once per generation step. Clears cache if needed.
+    /// Returns true if cache was cleared.
+    pub fn step(&mut self) -> bool {
+        self.step += 1;
+
+        // Always clear at step interval
+        if self.step % self.step_interval == 0 {
+            clear_cache();
+            self.last_clear = memory_snapshot();
+            return true;
+        }
+
+        // Check memory pressure
+        let snap = memory_snapshot();
+        if snap.peak > 0 {
+            let pressure = snap.active as f64 / snap.peak as f64;
+            if pressure > self.pressure_threshold {
+                clear_cache();
+                self.last_clear = memory_snapshot();
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Current step count.
+    pub fn current_step(&self) -> usize {
+        self.step
+    }
+
+    /// Memory snapshot from last cache clear.
+    pub fn last_snapshot(&self) -> MemorySnapshot {
+        self.last_clear
+    }
+
+    /// Take a fresh memory snapshot.
+    pub fn snapshot(&self) -> MemorySnapshot {
+        memory_snapshot()
+    }
+}
+
+/// Pre-flight memory check before starting inference.
+///
+/// Estimates whether there's enough GPU memory for the requested operation.
+/// Returns `Ok(snapshot)` if there's likely enough memory, or
+/// `Err(message)` with a description of the shortage.
+///
+/// This is advisory — actual memory needs depend on MLX's graph optimization.
+/// But it catches obvious cases (e.g., loading a 13GB model on a 16GB device
+/// with only 2GB free).
+pub fn preflight_check(estimated_bytes: usize) -> Result<MemorySnapshot, String> {
+    let snap = memory_snapshot();
+    let available = if snap.cache > 0 {
+        // Cache memory can be reclaimed
+        snap.cache
+    } else {
+        0
+    };
+
+    // Conservative: if active + estimated > peak * 1.1, warn
+    // (peak is our best proxy for "how much Metal let us allocate before")
+    if snap.peak > 0 && snap.active + estimated_bytes > (snap.peak as f64 * 1.1) as usize + available {
+        Err(format!(
+            "Estimated {:.1}MB needed, but only ~{:.1}MB available \
+             (active={:.1}MB, cache={:.1}MB, peak={:.1}MB). \
+             Consider clearing cache or using a smaller model/batch.",
+            estimated_bytes as f64 / 1e6,
+            available as f64 / 1e6,
+            snap.active as f64 / 1e6,
+            snap.cache as f64 / 1e6,
+            snap.peak as f64 / 1e6,
+        ))
+    } else {
+        Ok(snap)
+    }
+}

--- a/mlx-rs-core/src/metal_kernels.rs
+++ b/mlx-rs-core/src/metal_kernels.rs
@@ -93,8 +93,88 @@ const MODULATE_KERNEL_SOURCE: &str = r#"
     }
 "#;
 
+// Flash attention kernel using online softmax (no attention matrix materialization).
+// Handles both decode (Q=1) and prefill (Q>1) with causal masking and GQA.
+//
+// Inputs: q [num_q_heads, seq_q, head_dim], k [num_kv_heads, seq_kv, head_dim],
+//         v [num_kv_heads, seq_kv, head_dim]
+// Output: out [num_q_heads, seq_q, head_dim]
+//
+// Grid: (num_q_heads * seq_q) threadgroups, head_dim threads each.
+// Each threadgroup computes one output vector using cooperative dot product
+// reduction and per-thread online softmax accumulation.
+const FLASH_ATTENTION_KERNEL_SOURCE: &str = r#"
+    // Decode scale from bit-cast integer template arg
+    int _sb = scale_bits;
+    float scale = as_type<float>(_sb);
+
+    uint tg_idx = threadgroup_position_in_grid.x;
+    uint head_q = tg_idx / seq_q;
+    uint q_pos = tg_idx % seq_q;
+    uint d = thread_position_in_threadgroup.x;
+
+    // GQA: map query head to corresponding KV head
+    uint head_kv = head_q / gqa_factor;
+
+    // Load Q[head_q, q_pos, :] into shared memory (all threads cooperate)
+    threadgroup float shared_q[head_dim];
+    shared_q[d] = float(q[head_q * seq_q * head_dim + q_pos * head_dim + d]);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Shared memory for dot product reduction
+    threadgroup float shared_dot[head_dim];
+
+    // Determine max KV position for causal masking
+    uint max_kv_pos = seq_kv;
+    if (causal) {
+        uint absolute_q_pos = q_pos + kv_offset;
+        max_kv_pos = min(absolute_q_pos + 1, (uint)seq_kv);
+    }
+
+    // Online softmax accumulators (per thread, for output dimension d)
+    float m = -1e38;
+    float l = 0.0;
+    float acc = 0.0;
+
+    uint kv_base = head_kv * seq_kv * head_dim;
+
+    for (uint kv = 0; kv < max_kv_pos; kv++) {
+        uint kv_off = kv_base + kv * head_dim;
+
+        // Cooperative dot product: Q[q_pos] . K[kv]
+        shared_dot[d] = shared_q[d] * float(k[kv_off + d]);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // Tree reduction for dot product (power-of-2 head_dim)
+        for (uint stride = head_dim / 2; stride > 0; stride >>= 1) {
+            if (d < stride) {
+                shared_dot[d] += shared_dot[d + stride];
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+
+        float score = shared_dot[0] * scale;
+
+        // Online softmax update
+        float new_m = max(m, score);
+        float correction = exp(m - new_m);
+        float weight = exp(score - new_m);
+        l = l * correction + weight;
+        acc = acc * correction + weight * float(v[kv_off + d]);
+        m = new_m;
+    }
+
+    // Write normalized output
+    if (l > 0.0) {
+        out[head_q * seq_q * head_dim + q_pos * head_dim + d] = T(acc / l);
+    } else {
+        out[head_q * seq_q * head_dim + q_pos * head_dim + d] = T(0);
+    }
+"#;
+
 static SWIGLU_KERNEL: OnceLock<MetalKernel> = OnceLock::new();
 static MODULATE_KERNEL: OnceLock<MetalKernel> = OnceLock::new();
+static FLASH_ATTN_KERNEL: OnceLock<MetalKernel> = OnceLock::new();
 
 struct MetalKernel {
     kernel: mlx_sys::mlx_fast_metal_kernel,
@@ -335,5 +415,205 @@ pub fn fused_modulate(x: &Array, shift: &Array, scale: &Array) -> Result<Array, 
         mlx_sys::mlx_stream_free(stream);
 
         Ok(Array::from_ptr(result))
+    }
+}
+
+fn create_flash_attn_kernel() -> MetalKernel {
+    unsafe {
+        let q_name = CString::new("q").unwrap();
+        let k_name = CString::new("k").unwrap();
+        let v_name = CString::new("v").unwrap();
+        let out_name = CString::new("out").unwrap();
+
+        let input_names = mlx_sys::mlx_vector_string_new();
+        mlx_sys::mlx_vector_string_append_value(input_names, q_name.as_ptr());
+        mlx_sys::mlx_vector_string_append_value(input_names, k_name.as_ptr());
+        mlx_sys::mlx_vector_string_append_value(input_names, v_name.as_ptr());
+
+        let output_names = mlx_sys::mlx_vector_string_new();
+        mlx_sys::mlx_vector_string_append_value(output_names, out_name.as_ptr());
+
+        let source = CString::new(FLASH_ATTENTION_KERNEL_SOURCE).unwrap();
+        let header = CString::new("").unwrap();
+        let name = CString::new("flash_attention").unwrap();
+
+        let kernel = mlx_sys::mlx_fast_metal_kernel_new(
+            name.as_ptr(),
+            input_names,
+            output_names,
+            source.as_ptr(),
+            header.as_ptr(),
+            true,  // ensure_row_contiguous
+            false, // atomic_outputs
+        );
+
+        MetalKernel { kernel, input_names, output_names }
+    }
+}
+
+/// Flash attention using a custom Metal kernel with online softmax.
+///
+/// Computes scaled dot-product attention without materializing the full
+/// attention matrix. Supports GQA (grouped query attention) and causal masking.
+///
+/// Inputs must be 3D with batch*heads merged into the first dimension:
+/// * `queries` - `[num_q_heads, seq_q, head_dim]`
+/// * `keys` - `[num_kv_heads, seq_kv, head_dim]`
+/// * `values` - `[num_kv_heads, seq_kv, head_dim]`
+///
+/// `head_dim` must be a power of 2 (e.g., 64, 128).
+pub fn flash_attention(
+    queries: &Array,
+    keys: &Array,
+    values: &Array,
+    scale: f32,
+    causal: bool,
+    kv_offset: i32,
+) -> Result<Array, Exception> {
+    let kernel = FLASH_ATTN_KERNEL.get_or_init(create_flash_attn_kernel);
+
+    let q_shape = queries.shape();
+    let k_shape = keys.shape();
+
+    if q_shape.len() != 3 || k_shape.len() != 3 {
+        return Err(Exception::custom(
+            "flash_attention: expected 3D inputs [heads, seq, head_dim]",
+        ));
+    }
+
+    let num_q_heads = q_shape[0] as i32;
+    let seq_q = q_shape[1] as i32;
+    let head_dim = q_shape[2] as i32;
+    let num_kv_heads = k_shape[0] as i32;
+    let seq_kv = k_shape[1] as i32;
+
+    if num_q_heads % num_kv_heads != 0 {
+        return Err(Exception::custom(
+            "flash_attention: num_q_heads must be divisible by num_kv_heads",
+        ));
+    }
+    let gqa_factor = num_q_heads / num_kv_heads;
+
+    if head_dim & (head_dim - 1) != 0 {
+        return Err(Exception::custom(
+            "flash_attention: head_dim must be a power of 2",
+        ));
+    }
+
+    let dtype: u32 = queries.dtype().into();
+    let out_shape = [num_q_heads, seq_q, head_dim];
+
+    unsafe {
+        let stream = mlx_sys::mlx_default_gpu_stream_new();
+        let config = mlx_sys::mlx_fast_metal_kernel_config_new();
+
+        let type_name = CString::new("T").unwrap();
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_dtype(
+            config, type_name.as_ptr(), dtype);
+
+        let hd_name = CString::new("head_dim").unwrap();
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config, hd_name.as_ptr(), head_dim);
+
+        let sq_name = CString::new("seq_q").unwrap();
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config, sq_name.as_ptr(), seq_q);
+
+        let skv_name = CString::new("seq_kv").unwrap();
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config, skv_name.as_ptr(), seq_kv);
+
+        let gqa_name = CString::new("gqa_factor").unwrap();
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config, gqa_name.as_ptr(), gqa_factor);
+
+        // Encode float scale as int bits (no float template args in MLX custom kernels)
+        let scale_bits: i32 = f32::to_bits(scale) as i32;
+        let scale_name = CString::new("scale_bits").unwrap();
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config, scale_name.as_ptr(), scale_bits);
+
+        let causal_name = CString::new("causal").unwrap();
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_bool(
+            config, causal_name.as_ptr(), causal);
+
+        let offset_name = CString::new("kv_offset").unwrap();
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config, offset_name.as_ptr(), kv_offset);
+
+        // Grid: one threadgroup per (head, query_pos). head_dim threads per group.
+        let num_threadgroups = num_q_heads * seq_q;
+        let total_threads = num_threadgroups * head_dim;
+        mlx_sys::mlx_fast_metal_kernel_config_set_grid(config, total_threads, 1, 1);
+        mlx_sys::mlx_fast_metal_kernel_config_set_thread_group(config, head_dim, 1, 1);
+
+        mlx_sys::mlx_fast_metal_kernel_config_add_output_arg(
+            config, out_shape.as_ptr(), out_shape.len(), dtype);
+
+        let inputs = mlx_sys::mlx_vector_array_new();
+        mlx_sys::mlx_vector_array_append_value(inputs, queries.as_ptr());
+        mlx_sys::mlx_vector_array_append_value(inputs, keys.as_ptr());
+        mlx_sys::mlx_vector_array_append_value(inputs, values.as_ptr());
+
+        let mut outputs = mlx_sys::mlx_vector_array_new();
+        let ret = mlx_sys::mlx_fast_metal_kernel_apply(
+            &mut outputs, kernel.kernel, inputs, config, stream);
+
+        if ret != 0 {
+            mlx_sys::mlx_fast_metal_kernel_config_free(config);
+            mlx_sys::mlx_vector_array_free(inputs);
+            mlx_sys::mlx_vector_array_free(outputs);
+            mlx_sys::mlx_stream_free(stream);
+            return Err(Exception::custom("flash_attention Metal kernel failed"));
+        }
+
+        let mut result = mlx_sys::mlx_array_new();
+        mlx_sys::mlx_vector_array_get(&mut result, outputs, 0);
+
+        mlx_sys::mlx_fast_metal_kernel_config_free(config);
+        mlx_sys::mlx_vector_array_free(inputs);
+        mlx_sys::mlx_vector_array_free(outputs);
+        mlx_sys::mlx_stream_free(stream);
+
+        Ok(Array::from_ptr(result))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_flash_attention_decode() {
+        // Simulates Qwen3-TTS decode: 16 Q heads, 8 KV heads, Q=1, KV=4, head_dim=64
+        let q = Array::ones::<f32>(&[16, 1, 64]).unwrap();
+        let k = Array::ones::<f32>(&[8, 4, 64]).unwrap();
+        let v_data: Vec<f32> = (0..2048).map(|i| (i % 64) as f32 / 64.0).collect();
+        let v = Array::from_slice(&v_data, &[8, 4, 64]);
+
+        let scale = 1.0 / (64.0f32).sqrt();
+        let result = flash_attention(&q, &k, &v, scale, false, 0).unwrap();
+        result.eval().unwrap();
+
+        assert_eq!(result.shape(), &[16, 1, 64]);
+        let out = result.as_slice::<f32>();
+        assert!(!out.iter().any(|x| x.is_nan()), "output contains NaN");
+        assert!(out.iter().any(|x| *x != 0.0), "output is all zeros");
+    }
+
+    #[test]
+    fn test_flash_attention_causal_prefill() {
+        // Prefill: 4 Q heads, 2 KV heads, seq_q=3, seq_kv=3, head_dim=64
+        let q = Array::ones::<f32>(&[4, 3, 64]).unwrap();
+        let k = Array::ones::<f32>(&[2, 3, 64]).unwrap();
+        let v = Array::ones::<f32>(&[2, 3, 64]).unwrap();
+
+        let scale = 1.0 / (64.0f32).sqrt();
+        let result = flash_attention(&q, &k, &v, scale, true, 0).unwrap();
+        result.eval().unwrap();
+
+        assert_eq!(result.shape(), &[4, 3, 64]);
+        let out = result.as_slice::<f32>();
+        assert!(!out.iter().any(|x| x.is_nan()), "causal output has NaN");
     }
 }

--- a/qwen-image-mlx/examples/generate_fp32.rs
+++ b/qwen-image-mlx/examples/generate_fp32.rs
@@ -28,7 +28,7 @@ use safetensors::SafeTensors;
 use tokenizers::Tokenizer;
 
 // For cache clearing
-extern crate mlx_sys;
+extern crate mlx_rs_core;
 
 use qwen_image_mlx::qwen_full_precision::{QwenFullConfig, QwenFullTransformer, load_full_precision_weights};
 
@@ -299,7 +299,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Free text encoder to save ~2-3GB RAM (from flux2.c pattern)
     drop(text_encoder);
-    unsafe { mlx_sys::mlx_clear_cache(); }
+    mlx_rs_core::memory::clear_cache();
     println!("  Text encoder released to free memory");
 
     // Image parameters

--- a/qwen3-mlx/src/model.rs
+++ b/qwen3-mlx/src/model.rs
@@ -23,6 +23,7 @@ use tokenizers::Tokenizer;
 use mlx_rs_core::{
     cache::KeyValueCache,
     error::Error,
+    memory::MemoryGuard,
     utils::{
         create_attention_mask, initialize_rope, scaled_dot_product_attention,
         AttentionMask, FloatOrString, SdpaMask,
@@ -747,6 +748,7 @@ pub struct Generate<'a, C> {
     state: GenerateState<'a>,
     prefetched: Option<Array>,
     token_count: usize,
+    mem_guard: MemoryGuard,
 }
 
 pub enum GenerateState<'a> {
@@ -771,6 +773,7 @@ where
             state: GenerateState::Prefill { prompt_token },
             prefetched: None,
             token_count: 0,
+            mem_guard: MemoryGuard::default_guard(),
         }
     }
 
@@ -832,10 +835,7 @@ where
 
                 self.prefetched = Some(next_y);
                 self.token_count += 1;
-
-                if self.token_count % 256 == 0 {
-                    unsafe { mlx_sys::mlx_clear_cache(); }
-                }
+                self.mem_guard.step();
 
                 Some(Ok(current))
             }

--- a/qwen3-mlx/src/qwen2.rs
+++ b/qwen3-mlx/src/qwen2.rs
@@ -31,6 +31,7 @@ use mlx_rs_core::{
     Error,
     create_attention_mask,
     initialize_rope,
+    memory::MemoryGuard,
     FloatOrString,
     AttentionMask,
     SdpaMask,
@@ -758,6 +759,7 @@ pub struct Generate<'a, C> {
     state: GenerateState<'a>,
     prefetched: Option<Array>,
     token_count: usize,
+    mem_guard: MemoryGuard,
 }
 
 impl<'a, C> Generate<'a, C>
@@ -777,6 +779,7 @@ where
             state: GenerateState::Prefill { prompt_token },
             prefetched: None,
             token_count: 0,
+            mem_guard: MemoryGuard::default_guard(),
         }
     }
 
@@ -846,9 +849,7 @@ where
                 self.prefetched = Some(next_y);
 
                 self.token_count += 1;
-                if self.token_count % 256 == 0 {
-                    unsafe { mlx_sys::mlx_clear_cache(); }
-                }
+                self.mem_guard.step();
 
                 Some(Ok(current))
             }

--- a/qwen3-mlx/src/qwen3_moe.rs
+++ b/qwen3-mlx/src/qwen3_moe.rs
@@ -33,6 +33,7 @@ use mlx_rs_core::{
     fused_swiglu,
     create_attention_mask,
     initialize_rope,
+    memory::MemoryGuard,
     FloatOrString,
     AttentionMask,
     SdpaMask,
@@ -1012,6 +1013,7 @@ pub struct Generate<'a, C> {
     state: GenerateState<'a>,
     prefetched: Option<Array>,
     token_count: usize,
+    mem_guard: MemoryGuard,
 }
 
 impl<'a, C> Generate<'a, C>
@@ -1031,6 +1033,7 @@ where
             state: GenerateState::Prefill { prompt_token },
             prefetched: None,
             token_count: 0,
+            mem_guard: MemoryGuard::default_guard(),
         }
     }
 
@@ -1100,9 +1103,7 @@ where
                 self.prefetched = Some(next_y);
 
                 self.token_count += 1;
-                if self.token_count % 256 == 0 {
-                    unsafe { mlx_sys::mlx_clear_cache(); }
-                }
+                self.mem_guard.step();
 
                 Some(Ok(current))
             }

--- a/qwen3-tts-mlx/src/generate.rs
+++ b/qwen3-tts-mlx/src/generate.rs
@@ -162,6 +162,7 @@ fn run_generation_loop(
     };
 
     let mut all_codes: Vec<[u32; 16]> = Vec::new();
+    let mut mem_guard = mlx_rs_core::memory::MemoryGuard::default_guard();
 
     // Repetition loop detection: if the same token0 repeats too many times
     // in a window, the model is stuck — break early and return what we have.
@@ -263,9 +264,7 @@ fn run_generation_loop(
         logits = result.0;
         hidden = result.1;
 
-        if step > 0 && step % 256 == 0 {
-            unsafe { mlx_sys::mlx_clear_cache() };
-        }
+        mem_guard.step();
     }
 
     Ok(all_codes)
@@ -834,6 +833,8 @@ pub struct GenerationState {
     eos_steering: (usize, f32),
     /// Unit mask for EOS logit steering
     eos_unit_mask: Array,
+    /// GPU memory guard — adaptive cache clearing
+    mem_guard: mlx_rs_core::memory::MemoryGuard,
 }
 
 impl GenerationState {
@@ -932,6 +933,7 @@ impl GenerationState {
             recent_tokens: Vec::new(),
             eos_steering: (target_frames, speed),
             eos_unit_mask,
+            mem_guard: mlx_rs_core::memory::MemoryGuard::default_guard(),
         })
     }
 
@@ -1049,9 +1051,7 @@ impl GenerationState {
 
             self.step += 1;
 
-            if self.step > 0 && self.step % 256 == 0 {
-                unsafe { mlx_sys::mlx_clear_cache() };
-            }
+            self.mem_guard.step();
         }
 
         if frames.is_empty() {

--- a/qwen3-tts-mlx/src/talker.rs
+++ b/qwen3-tts-mlx/src/talker.rs
@@ -34,9 +34,11 @@ pub struct TalkerAttention {
     /// KV cache indexing is unaffected — only the RoPE rotation angles change.
     pub rope_speed_factor: f32,
 
-    pub q_proj: MaybeQuantized<nn::Linear>,
-    pub k_proj: MaybeQuantized<nn::Linear>,
-    pub v_proj: MaybeQuantized<nn::Linear>,
+    /// Merged QKV projection: one quantized_matmul instead of three.
+    /// Output dim = n_heads*head_dim + 2*n_kv_heads*head_dim.
+    pub qkv_proj: MaybeQuantized<nn::Linear>,
+    pub q_dim: i32,  // n_heads * head_dim
+    pub kv_dim: i32, // n_kv_heads * head_dim
     pub o_proj: MaybeQuantized<nn::Linear>,
     pub q_norm: nn::RmsNorm,
     pub k_norm: nn::RmsNorm,
@@ -53,9 +55,13 @@ impl TalkerAttention {
         let b = shape[0];
         let l = shape[1];
 
-        let queries = self.q_proj.forward(x)?;
-        let keys = self.k_proj.forward(x)?;
-        let values = self.v_proj.forward(x)?;
+        // Batched QKV projection: one matmul instead of three
+        let qkv = self.qkv_proj.forward(x)?;
+        let qd = self.q_dim;
+        let kvd = self.kv_dim;
+        let queries = qkv.index((.., .., ..qd));
+        let keys = qkv.index((.., .., qd..(qd + kvd)));
+        let values = qkv.index((.., .., (qd + kvd)..));
 
         // Reshape to [B, L, heads, head_dim] then transpose to [B, heads, L, head_dim]
         let mut queries = self
@@ -198,9 +204,9 @@ pub struct CodePredictorAttention {
     pub head_dim: i32,
     pub scale: f32,
 
-    pub q_proj: MaybeQuantized<nn::Linear>,
-    pub k_proj: MaybeQuantized<nn::Linear>,
-    pub v_proj: MaybeQuantized<nn::Linear>,
+    pub qkv_proj: MaybeQuantized<nn::Linear>,
+    pub q_dim: i32,
+    pub kv_dim: i32,
     pub o_proj: MaybeQuantized<nn::Linear>,
     pub q_norm: nn::RmsNorm,
     pub k_norm: nn::RmsNorm,
@@ -218,9 +224,12 @@ impl CodePredictorAttention {
         let b = shape[0];
         let l = shape[1];
 
-        let queries = self.q_proj.forward(x)?;
-        let keys = self.k_proj.forward(x)?;
-        let values = self.v_proj.forward(x)?;
+        let qkv = self.qkv_proj.forward(x)?;
+        let qd = self.q_dim;
+        let kvd = self.kv_dim;
+        let queries = qkv.index((.., .., ..qd));
+        let keys = qkv.index((.., .., qd..(qd + kvd)));
+        let values = qkv.index((.., .., (qd + kvd)..));
 
         let mut queries = self
             .q_norm
@@ -1067,6 +1076,57 @@ fn make_linear_with_bias(
     Ok((linear, bias))
 }
 
+/// Merge Q/K/V projections into a single batched linear layer.
+/// Concatenates weight/scales/biases along output dim (axis 0).
+fn merge_qkv_projections(
+    weights: &HashMap<String, Array>,
+    prefix: &str,
+    quant: Option<&QuantizationConfig>,
+    _q_dim: i32,
+    _kv_dim: i32,
+) -> Result<MaybeQuantized<nn::Linear>> {
+    use mlx_rs::ops::concatenate_axis;
+
+    if let Some(q) = quant {
+        let q_w = get_weight(weights, &format!("{prefix}.q_proj.weight"))?;
+        let k_w = get_weight(weights, &format!("{prefix}.k_proj.weight"))?;
+        let v_w = get_weight(weights, &format!("{prefix}.v_proj.weight"))?;
+        let q_s = get_weight(weights, &format!("{prefix}.q_proj.scales"))?;
+        let k_s = get_weight(weights, &format!("{prefix}.k_proj.scales"))?;
+        let v_s = get_weight(weights, &format!("{prefix}.v_proj.scales"))?;
+        let q_b = get_weight(weights, &format!("{prefix}.q_proj.biases"))?;
+        let k_b = get_weight(weights, &format!("{prefix}.k_proj.biases"))?;
+        let v_b = get_weight(weights, &format!("{prefix}.v_proj.biases"))?;
+
+        let merged_w = concatenate_axis(&[&q_w, &k_w, &v_w], 0)?;
+        let merged_s = concatenate_axis(&[&q_s, &k_s, &v_s], 0)?;
+        let merged_b = concatenate_axis(&[&q_b, &k_b, &v_b], 0)?;
+
+        let inner = nn::Linear {
+            weight: Param::new(merged_w),
+            bias: Param::new(None),
+        };
+        let mut ql = nn::QuantizedLinear {
+            group_size: q.group_size,
+            bits: q.bits,
+            scales: Param::new(merged_s),
+            biases: Param::new(merged_b),
+            inner,
+        };
+        ql.freeze_parameters(true);
+        Ok(MaybeQuantized::Quantized(ql))
+    } else {
+        let q_w = get_weight(weights, &format!("{prefix}.q_proj.weight"))?;
+        let k_w = get_weight(weights, &format!("{prefix}.k_proj.weight"))?;
+        let v_w = get_weight(weights, &format!("{prefix}.v_proj.weight"))?;
+        let merged_w = concatenate_axis(&[&q_w, &k_w, &v_w], 0)?;
+        Ok(MaybeQuantized::Original(nn::Linear {
+            weight: Param::new(merged_w),
+            bias: Param::new(None),
+        }))
+    }
+}
+
 /// Load a linear layer as MaybeQuantized, auto-detecting from quant config.
 fn load_maybe_quantized(
     weights: &HashMap<String, Array>,
@@ -1115,6 +1175,14 @@ fn load_talker_attention(
         .build()
         .map_err(|e| Error::Model(format!("RoPE build error: {e}")))?;
 
+    let q_dim = config.num_attention_heads * config.head_dim;
+    let kv_dim = config.num_key_value_heads * config.head_dim;
+
+    // Merge Q/K/V projections into a single batched matmul
+    let qkv_proj = merge_qkv_projections(
+        weights, prefix, quant, q_dim, kv_dim,
+    )?;
+
     Ok(TalkerAttention {
         n_heads: config.num_attention_heads,
         n_kv_heads: config.num_key_value_heads,
@@ -1122,9 +1190,9 @@ fn load_talker_attention(
         scale: (config.head_dim as f32).sqrt().recip(),
         rope,
         rope_speed_factor: 1.0,
-        q_proj: load_maybe_quantized(weights, &format!("{prefix}.q_proj"), quant)?,
-        k_proj: load_maybe_quantized(weights, &format!("{prefix}.k_proj"), quant)?,
-        v_proj: load_maybe_quantized(weights, &format!("{prefix}.v_proj"), quant)?,
+        qkv_proj,
+        q_dim,
+        kv_dim,
         o_proj: load_maybe_quantized(weights, &format!("{prefix}.o_proj"), quant)?,
         q_norm: load_rms_norm(weights, &format!("{prefix}.q_norm"), config.rms_norm_eps)?,
         k_norm: load_rms_norm(weights, &format!("{prefix}.k_norm"), config.rms_norm_eps)?,
@@ -1155,14 +1223,18 @@ fn load_code_predictor_attention(
         .build()
         .map_err(|e| Error::Model(format!("RoPE build error: {e}")))?;
 
+    let q_dim = config.num_attention_heads * head_dim;
+    let kv_dim = config.num_key_value_heads * head_dim;
+    let qkv_proj = merge_qkv_projections(weights, prefix, quant, q_dim, kv_dim)?;
+
     Ok(CodePredictorAttention {
         n_heads: config.num_attention_heads,
         n_kv_heads: config.num_key_value_heads,
         head_dim,
         scale: (head_dim as f32).sqrt().recip(),
-        q_proj: load_maybe_quantized(weights, &format!("{prefix}.q_proj"), quant)?,
-        k_proj: load_maybe_quantized(weights, &format!("{prefix}.k_proj"), quant)?,
-        v_proj: load_maybe_quantized(weights, &format!("{prefix}.v_proj"), quant)?,
+        qkv_proj,
+        q_dim,
+        kv_dim,
         o_proj: load_maybe_quantized(weights, &format!("{prefix}.o_proj"), quant)?,
         q_norm: load_rms_norm(weights, &format!("{prefix}.q_norm"), config.rms_norm_eps())?,
         k_norm: load_rms_norm(weights, &format!("{prefix}.k_norm"), config.rms_norm_eps())?,

--- a/qwen3.5-35B-mlx/src/lib.rs
+++ b/qwen3.5-35B-mlx/src/lib.rs
@@ -17,6 +17,7 @@ pub use cache::HybridCache;
 pub use config::ModelArgs;
 pub use model::{load_model, Model};
 pub use mlx_rs_core::{error::Error, load_tokenizer};
+use mlx_rs_core::memory::MemoryGuard;
 
 use mlx_rs::{
     argmax_axis, array, categorical,
@@ -50,6 +51,7 @@ pub struct Generate<'a> {
     state: GenerateState<'a>,
     prefetched: Option<Array>,
     token_count: usize,
+    mem_guard: MemoryGuard,
 }
 
 enum GenerateState<'a> {
@@ -66,6 +68,7 @@ impl<'a> Generate<'a> {
             state: GenerateState::Prefill { prompt },
             prefetched: None,
             token_count: 0,
+            mem_guard: MemoryGuard::default_guard(),
         }
     }
 
@@ -115,14 +118,7 @@ impl Iterator for Generate<'_> {
 
                 self.prefetched = Some(next_y);
                 self.token_count += 1;
-
-                if self.token_count % 256 == 0 {
-                    // SAFETY: mlx_clear_cache releases GPU memory for completed graphs.
-                    // Safe to call between generation steps when no evaluation is in progress.
-                    unsafe {
-                        mlx_sys::mlx_clear_cache();
-                    }
-                }
+                self.mem_guard.step();
 
                 Some(Ok(current))
             }


### PR DESCRIPTION
## Summary
Three related performance / infrastructure changes, split out from the bundle that previously sat on top of #22.

### 1. MemoryGuard (new in `mlx-rs-core/src/memory.rs`)
Adaptive GPU cache clearing instead of the previous fixed `if step % 256 == 0 { mlx_clear_cache() }` pattern that was duplicated across crates.

- `MemoryGuard::default_guard()` clears on a step interval **or** when active/peak pressure crosses a threshold.
- `eval_with_retry` detects OOM, clears, and retries up to N times.
- `memory_snapshot` wraps `mlx_get_active_memory` / `mlx_get_cache_memory` / `mlx_get_peak_memory`.
- `clear_cache()` is a safe public wrapper so callers no longer need `unsafe { mlx_sys::mlx_clear_cache() }`.

Adopted in:
- `mixtral-mlx/src/model.rs`
- `qwen3-mlx/src/{model,qwen2,qwen3_moe}.rs`
- `qwen3-tts-mlx/src/generate.rs`
- `qwen3.5-35B-mlx/src/lib.rs`
- `gpt-sovits-mlx/src/models/t2s.rs`
- `qwen-image-mlx/examples/generate_fp32.rs` (uses the safe `clear_cache()` wrapper)

### 2. Flash-attention Metal kernel (new in `mlx-rs-core/src/metal_kernels.rs`)
Online-softmax attention kernel that does not materialize the `[B, H, L, L]` attention matrix. GQA-native, supports causal masking with `kv_offset` for cached prefill+decode. Re-exported as `mlx_rs_core::flash_attention`. Includes decode + causal-prefill smoke tests.

The kernel is currently unused at call sites (it is staged for ASR / FLUX long-sequence encoder use); shipping the infrastructure here keeps the call-site adopters small.

### 3. Batched QKV projection in `qwen3-tts-mlx/src/talker.rs`
Merge `q_proj` / `k_proj` / `v_proj` into a single quantized `Linear` at load time (concat weight / scales / biases on the output dim), then slice after the merged forward. Applied to both `TalkerAttention` and `CodePredictorAttention`.

## Why grouped
The MemoryGuard adoption, the new Metal kernel, and the QKV-merge all live in or are exported from `mlx-rs-core`, and the talker.rs change touches the same file as the MemoryGuard adoption in `qwen3-tts-mlx`. Splitting them further would split a single file or scatter `mlx-rs-core/src/lib.rs` re-exports across PRs.

## Test plan
- [x] `cargo check -p mlx-rs-core -p mixtral-mlx -p qwen3-mlx -p qwen3-tts-mlx -p qwen3-5-35b-mlx -p gpt-sovits-mlx` clean
- [ ] `cargo test -p mlx-rs-core metal_kernels::tests` (requires Metal device)
- [ ] qwen3-tts end-to-end smoke (will run on mini4 once stacked on top of #22)

## Out of scope / split-off PRs
- macOS-14 deployment target fix: #22 (now narrowed to `build.rs` only)
- `fast::scaled_dot_product_attention` adoption in vision/audio encoders: separate PR (see other open PR)