### PR TITLE
refactor: use mlx_rs::fast::scaled_dot_product_attention across model crates

### DIFF
--- a/deepseek-ocr2-mlx/src/qwen2_encoder.rs
+++ b/deepseek-ocr2-mlx/src/qwen2_encoder.rs
@@ -98,11 +98,9 @@ impl Qwen2Attention {
             v
         };
 
-        // Attention with custom mask
-        let attn = q.matmul(&k.transpose_axes(&[0, 1, 3, 2])?)?.multiply(mlx_rs::array!(self.scale))?;
-        let attn = attn.add(mask)?;
-        let attn = ops::softmax_axis(&attn, -1, true)?;
-        let out = attn.matmul(&v)?;
+        // Use MLX SDPA with additive mask — avoids materializing full attention matrix
+        let mask_ref = mlx_rs::fast::ScaledDotProductAttentionMask::Array(mask);
+        let out = mlx_rs::fast::scaled_dot_product_attention(q, k, v, self.scale, Some(mask_ref))?;
 
         let out = out
             .transpose_axes(&[0, 2, 1, 3])?

--- a/deepseek-ocr2-mlx/src/vision.rs
+++ b/deepseek-ocr2-mlx/src/vision.rs
@@ -112,17 +112,11 @@ impl SamAttention {
         // Attention: use SDPA (no mask for bidirectional)
         // q, k, v: [B, nH, H*W, hd]
         let attn = if self.use_rel_pos && (*self.rel_pos_h).shape()[0] > 0 {
-            // Compute attention with relative position bias
-            let scores = q.matmul(&k.transpose_axes(&[0, 1, 3, 2])?)?.multiply(array!(self.scale))?;
-
-            // Add decomposed relative position bias
+            // SDPA with relative position bias as additive mask
             let bias = self.compute_rel_pos_bias(&q, h, w)?;
-            let scores = scores.add(&bias)?;
-
-            let attn_weights = ops::softmax_axis(&scores, -1, true)?;
-            attn_weights.matmul(&v)?
+            let mask = mlx_rs::fast::ScaledDotProductAttentionMask::Array(&bias);
+            mlx_rs::fast::scaled_dot_product_attention(&q, &k, &v, self.scale, Some(mask))?
         } else {
-            // Simple SDPA without bias
             mlx_rs::fast::scaled_dot_product_attention(&q, &k, &v, self.scale, None)?
         };
 

--- a/funasr-mlx/src/paraformer.rs
+++ b/funasr-mlx/src/paraformer.rs
@@ -41,7 +41,7 @@ use mlx_rs::{
     macros::ModuleParameters,
     module::{Module, Param},
     nn,
-    ops::{self, indexing::IndexOp, softmax_axis},
+    ops::{self, indexing::IndexOp},
     Array,
 };
 
@@ -514,10 +514,8 @@ impl Module<&Array> for SanmAttention {
             .reshape(&[batch, seq_len, self.num_heads, self.head_dim])?
             .transpose_axes(&[0, 2, 1, 3])?;
 
-        let k_t = k.transpose_axes(&[0, 1, 3, 2])?;
-        let scores = q.matmul(&k_t)?.multiply(array!(self.scale))?;
-        let attn_weights = softmax_axis(&scores, -1, None)?;
-        let attn_out = attn_weights.matmul(&v)?;
+        // Use MLX SDPA — avoids materializing full attention matrix for long sequences
+        let attn_out = mlx_rs::fast::scaled_dot_product_attention(q, k, v, self.scale, None)?;
 
         let attn_out = attn_out
             .transpose_axes(&[0, 2, 1, 3])?
@@ -1004,10 +1002,8 @@ impl ParaformerDecoderLayer {
             .reshape(&[batch, src_len, self.num_heads, self.head_dim])?
             .transpose_axes(&[0, 2, 1, 3])?;
 
-        let k_t = k.transpose_axes(&[0, 1, 3, 2])?;
-        let scores = q.matmul(&k_t)?.multiply(array!(self.scale))?;
-        let attn_weights = softmax_axis(&scores, -1, None)?;
-        let attn_out = attn_weights.matmul(&v)?;
+        // Use MLX SDPA — avoids materializing full attention matrix
+        let attn_out = mlx_rs::fast::scaled_dot_product_attention(q, k, v, self.scale, None)?;
 
         let attn_out = attn_out
             .transpose_axes(&[0, 2, 1, 3])?

--- a/qwen3-vl-mlx/src/lib.rs
+++ b/qwen3-vl-mlx/src/lib.rs
@@ -311,12 +311,8 @@ impl VisionAttention {
             .reshape(&[1, n, self.num_heads, self.head_dim])?
             .transpose_axes(&[0, 2, 1, 3])?;
 
-        // Scaled dot-product attention (full, no mask)
-        let scale = array!(self.scale);
-        let scores = q.matmul(&k.transpose_axes(&[0, 1, 3, 2])?)?.multiply(&scale)?;
-        let attn = mlx_rs::ops::softmax_axis(&scores, -1, None)?;
-        let out = attn
-            .matmul(&v)?
+        // Use MLX SDPA — avoids materializing full attention matrix
+        let out = mlx_rs::fast::scaled_dot_product_attention(q, k, v, self.scale, None)?
             .transpose_axes(&[0, 2, 1, 3])?
             .reshape(&[n, hidden])?;
 


### PR DESCRIPTION
## Summary
Replace manual attention implementations (`Q @ K^T -> softmax -> @ V`) with the fused `mlx_rs::fast::scaled_dot_product_attention` primitive in vision / audio encoders.

| Crate | File | Notes |
|---|---|---|
| deepseek-ocr2-mlx | `src/qwen2_encoder.rs` | text/vision encoder, additive mask via `ScaledDotProductAttentionMask::Array` |
| deepseek-ocr2-mlx | `src/vision.rs` | SAM attention; relative-position bias passed as additive mask when enabled |
| funasr-mlx | `src/paraformer.rs` | SANM encoder + decoder cross/self attention |
| qwen3-vl-mlx | `src/lib.rs` | `VisionAttention` (no mask) |

Each call site previously used the same scale and (when present) the same additive mask we now hand directly to SDPA, so this is a drop-in replacement modulo numerical reordering.

## Why
- Avoids materializing the `[B, H, L, L]` attention matrix, lowering peak GPU memory on long sequences (relevant for OCR / ASR).
- The fused kernel runs softmax with the QK^T multiply, improving throughput.

## Test plan
- [x] `cargo check -p deepseek-ocr2-mlx -p funasr-mlx -p qwen3-vl-mlx` clean
- [ ] Existing crate-level tests pass on a Metal host
- [ ] OCR / ASR end-to-end smoke remains functionally equivalent

## Out of scope / split-off PRs
- macOS-14 deployment target fix: #22
- MemoryGuard / flash-attention kernel / batched QKV: #23